### PR TITLE
Change meaning of "airQualityIndex" and set "Sensor" capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ Install this Driver and create a New Virtual Device.
 <li>Click Save and your new device is ready to configure.</li>
 <li>Copy / Paste your AirNow API Key and choose a Poll interval and which AQI reading you would like.</li></UL>
 
-Note that AQI is an index, a number between 1 and 6. Each Index has been assigned a Color and Health rating and that is displayed too.
+Each of the six AQI categories has been assigned a Color and Health rating and that is displayed too.
 
-The Standard AQ Attribute is <b>airQualityIndex</b>. Additional Attributes supported by this driver are: <b>O3, PM2.5 and PM10</b> as well as the AQ index as a color (<b>airQualityColor</b>).
+The Standard AQ Attribute is <b>airQualityIndex</b>. Additional Attributes supported by this driver are: <b>O3, PM2.5 and PM10</b> as well as the AQ category as a color (<b>airQualityColor</b>).


### PR DESCRIPTION
This pull request replaces an earlier one; replaced to use a more specific source branch.

I changed the meaning of the "airQualityIndex" attribute. It believe this change is correct.

    According to the docs at https://docs.hubitat.com/index.php?title=Driver_Capability_List#AirQuality the airQualityIndex attribute is supposed range from 0 to 500, meaning it should be the full PM10-equivalent value, not the 6-category meaning previously used.
    My physical Ecowitt air quality sensor also uses this larger value for its airQualityIndex attribute. I want the two devices to be equivalent, at least with the official airQualityIndex attribute for the supported AirQuality capability.

I also declared the "Sensor" capability in the metadata, so more apps are willing to query this device's attributes (especially GoogleSheetsLogging)
Also explicitly declared the airQualityIndex attribute.
